### PR TITLE
Rewrite FFI to match the curried branch of Idris2-Lua

### DIFF
--- a/src/Plugin.idr
+++ b/src/Plugin.idr
@@ -21,7 +21,7 @@ import Foreign
 data Server : Type where
 data Client : Type where
 
-%foreign "function(s, h) return {args={'--ide-mode-socket', s}, stdio={nil, h, nil}} end"
+%foreign "function(s) return function(h) return {args={'--ide-mode-socket', s}, stdio={nil, h, nil}} end end"
 prim__spawnOpts : String -> OpaqueDict -> OpaqueDict
 
 spawnOpts : String
@@ -41,19 +41,19 @@ spawnIdris2 host port = do
                    (primIO $ nvimCommand  "echom 'Idris2 stdout closed'")
   pure (handle, stdout)
 
-%foreign "function() vim.fn.getcurpos() end"
+%foreign "function(_) return vim.fn.getcurpos() end"
 getCurPos : PrimIO OpaqueDict
 
-%foreign "function(pos) vim.fn.setpos('.', pos) end"
+%foreign "function(pos) return function(_) vim.fn.setpos('.', pos) end end"
 setCurPos : OpaqueDict -> PrimIO ()
 
-%foreign "function(l, s) vim.fn.append(l, vim.split(s, '\\n')) end"
+%foreign "function(l) return function(s) return function(_) vim.fn.append(l, vim.split(s, '\\n')) end end end"
 appendLines : Int -> String -> PrimIO ()
 
-%foreign "function(l) vim.fn.deletebufline('%', l) end"
+%foreign "function(l) return function(_) vim.fn.deletebufline('%', l) end end"
 deleteLine : Int -> PrimIO ()
 
-%foreign "function(s) return vim.fn.line(s) end"
+%foreign "function(s) return function(_) return vim.fn.line(s) end end"
 line : String -> PrimIO Int
 
 writeToBuffer : String -> IO ()
@@ -242,10 +242,10 @@ spawnAndConnectIdris2 (shost, sport) (chost, cport) = do
                    (do primIO $ nvimCommand "echom 'Idris2 stdout closed'"
                        quitServer)
 
-%foreign "function(name) return vim.fn.bufexists(name) end"
+%foreign "function(name) return function(_) return vim.fn.bufexists(name) end end"
 bufexists : String -> PrimIO Int
 
-%foreign "function(type) vim.bo.buftype = type end"
+%foreign "function(type) return function(_) vim.bo.buftype = type end end"
 setBuftype : String -> PrimIO ()
 
 main : IO ()

--- a/src/System/FFI/Lua.idr
+++ b/src/System/FFI/Lua.idr
@@ -10,7 +10,7 @@ data External : Type where [external]
 %foreign "idris.support.world|support"
 world : External
 
-%foreign "function(w) end"
+%foreign "function(_) end"
 prim__compile : List External -> PrimIO ()
 
 export
@@ -30,7 +30,7 @@ public export
 data List : List Type -> Type where
   MkList : (n : Nat) -> OpaqueDict -> n = length ts => List ts
 
-%foreign "function() return {} end"
+%foreign "{}"
 prim__empty : OpaqueDict
 
 namespace Dict
@@ -39,10 +39,10 @@ namespace Dict
     First : FieldType n t ((n, t) :: ts)
     Later : FieldType n t ts -> FieldType n t (f :: ts)
 
-  %foreign "function(_, d, n) return d[n] end"
+  %foreign "function(_) return function(d) return function(n) return d[n] end end end"
   prim__getField : OpaqueDict -> (n : String) -> ty
 
-  %foreign "function(_, d, n, v) d[n] = v end"
+  %foreign "function(_) return function(d) return function(n) return function(v) return function(_) return d[n] = v end end end end end"
   prim__setField : OpaqueDict -> (n : String) -> ty -> PrimIO ()
 
   public export %inline
@@ -69,10 +69,10 @@ namespace List
     First : FieldType 1 t (t :: ts)
     Later : FieldType n t ts -> FieldType (S n) t (t' :: ts)
 
-  %foreign "function(_, l, n) return l[n] end"
+  %foreign "function(_) return function(d) return function(n) return d[n] end end end"
   prim__getField : OpaqueDict -> (n : Nat) -> ty
 
-  %foreign "function(_, l, n, v) d[n] = v end"
+  %foreign "function(_) return function(d) return function(n) return function(v) return function(_) return d[n] = v end end end end end"
   prim__setField : OpaqueDict -> (n : Nat) -> ty -> PrimIO ()
 
   public export %inline
@@ -100,7 +100,7 @@ namespace List
                                  rewrite lengthSuc ts t [] in
                                  rewrite appendNilRightNeutral ts in Refl})
 
-%foreign "function(v) return v == nil end"
+%foreign "function(v) return function(_) return v == nil end end"
 prim__isNil : OpaqueDict -> PrimIO Bool
 
 isNil : HasIO io => OpaqueDict -> io Bool


### PR DESCRIPTION
Basically every foreign definition is rewritten to a curried function signature.
Currying every global definition lets us have more predictable cross-language interactions.

Hopefully I haven't made any typos in the FFI Strings 😅 