### PR TITLE
Go to definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Keybindings can be customized by setting global options:
 | ------ | ----------- | --------------- |
 | `idris2_loadCurrent_key` | Reload the current file | `<LocalLeader>r` |
 | `idris2_typeOf_key` | Type of the name under cursor | `<LocalLeader>t` |
+| `idris2_typeOfPrompt_key` | Type of the name entered from a prompt window | `<LocalLeader>T` |
+| `idris2_jumpTo_key` | Jump-to-definition by the name under the cursor | `<LocalLeader>j` |
+| `idris2_jumpToPrompt_key` | Jump-to-definition by the name entered from a prompt window | `<LocalLeader>J` |
 | `idris2_docOverview` | Documentation overview of the name under cursor | `<LocalLeader>d` |
 | `idris2_caseSplit_key` | Try case-split on argument under cursor | `<LocalLeader>c` |
 | `idris2_exprSearch_key` | Try expression search on hole under cursor | `<LocalLeader>s` |

--- a/src/Foreign.idr
+++ b/src/Foreign.idr
@@ -187,6 +187,16 @@ getSelection = primIO prim__getSelection
 %foreign "_ => vim.api.nvim_command('w')"
 prim__saveBuffer : PrimIO ()
 
+%foreign "name, _ => vim.fn.bufexists(name)"
+prim__bufexists : String -> PrimIO Int
+
+export
+bufexists : HasIO io => String -> io Bool
+bufexists bufName = do
+  case !(primIO $ prim__bufexists bufName) of
+    0 => pure False
+    _ => pure True
+
 export
 saveBuffer : HasIO io => io ()
 saveBuffer = primIO prim__saveBuffer
@@ -198,8 +208,19 @@ export
 isBufferModified : HasIO io => io Bool
 isBufferModified = primIO prim__isBufferModified
 
-export %foreign "cmd, _ => vim.api.nvim_command(cmd)"
-nvimCommand : String -> PrimIO ()
+%foreign "cmd, _ => vim.api.nvim_command(cmd)"
+prim__nvimCommand : String -> PrimIO ()
+
+%foreign "expr, _ => vim.api.nvim_eval(expr)"
+prim__nvimEval : String -> PrimIO ty
+
+export
+nvimCommand : HasIO io => String -> io ()
+nvimCommand = primIO . prim__nvimCommand
+
+export
+nvimEval : HasIO io => String -> io ty
+nvimEval = primIO . prim__nvimEval
 
 %foreign "key, cmd, _ => vim.api.nvim_set_keymap('n', key, cmd, { noremap = true, silent = true })"
 prim__nnoremap : String -> String -> PrimIO ()

--- a/src/Plugin.idr
+++ b/src/Plugin.idr
@@ -169,7 +169,6 @@ where
                      pure $ reverse got
                    else do
                      let line = trimNewLineAtEnd line
-                     nvimCommand $ "echom 'runFind: " ++ show line ++ "'"
                      rec f (line :: got)
 
 record NamePositionInfo where

--- a/src/Plugin.idr
+++ b/src/Plugin.idr
@@ -1,8 +1,13 @@
 module Plugin
 
 import Data.List
+import Data.List1
 import Data.Ref
 import Data.Strings
+
+import System.File
+import System
+
 import Language.Reflection
 
 import Idris.IDEMode.Commands
@@ -10,6 +15,7 @@ import Idris.IDEMode.Parser
 import Parser.Lexer.Source
 import Parser.Support
 import Utils.Hex
+import Utils.Path
 
 import Commands
 import Foreign
@@ -21,7 +27,23 @@ import Foreign
 data Server : Type where
 data Client : Type where
 
-%foreign "s, h => {args={'--ide-mode-socket', s}, stdio={nil, h, nil}}"
+public export
+data Parameters : Type where
+  [noHints] -- Auto search won't be able to construct instances of this type
+            -- straight through this constructor anymore
+  MkParameters : (sourceDir : String) -> Parameters
+
+namespace Parameters
+  public export
+  sourceDir : Parameters -> String
+  sourceDir (MkParameters srcDir) = srcDir
+
+  public export
+  (.sourceDir) : Parameters -> String
+  (.sourceDir) = sourceDir
+
+
+%foreign "s, h => {args={'-p', 'contrib', '--ide-mode-socket', s}, stdio={nil, h, nil}}"
 prim__spawnOpts : String -> OpaqueDict -> OpaqueDict
 
 spawnOpts : String
@@ -34,11 +56,11 @@ spawnIdris2 : String -> Int
 spawnIdris2 host port = do
   stdout <- newPipe
   let opts = spawnOpts (host ++ ":" ++ show port) stdout
-  d <- spawn "idris2" opts (\code, signal => primIO $ nvimCommand $ "echom 'Idris2 process closed with code " ++ show code ++ "'")
+  d <- spawn "idris2" opts (\code, signal => nvimCommand $ "echom 'Idris2 process closed with code " ++ show code ++ "'")
   let handle : OpaqueDict = getField d "handle"
-  readStart stdout (\msg => primIO $ nvimCommand $ "echom 'server: " ++ msg ++ "'")
-                   (\err => primIO $ nvimCommand $ "echom 'err: " ++ err ++ "'")
-                   (primIO $ nvimCommand  "echom 'Idris2 stdout closed'")
+  readStart stdout (\msg => nvimCommand $ "echom 'server: " ++ msg ++ "'")
+                   (\err => nvimCommand $ "echom 'err: " ++ err ++ "'")
+                   (nvimCommand  "echom 'Idris2 stdout closed'")
   pure (handle, stdout)
 
 %foreign "_ => vim.fn.getcurpos()"
@@ -62,23 +84,62 @@ currenttime : PrimIO String
 %foreign "s, _ => vim.fn.bufwinnr(s)"
 bufwinnr : String -> PrimIO Int
 
+%foreign "idris.support.fzfWindowBottom"
+fzfWindowBottom : (name : String)
+               -> (options : List String)
+               -> (fn : String -> IO ())
+               -> IO ()
+
+%foreign "idris.support.matchlist"
+matchlist : (str : String) -> (pattern : String) -> List String
+
+responseBufferName : String
+responseBufferName = "idris-response"
+
+trimNewLineAtEnd : (str : String) -> String
+trimNewLineAtEnd str =
+  fastPack $ reverse $ dropWhile (== '\n') (reverse (fastUnpack str))
+
+||| Runs a system command to find out where
+||| the package source files are located. By default,
+||| it uses a subdirectory of the local Idris 2 installation
+getSourceDirectory : IO String
+getSourceDirectory = do
+  let cmd = "idris2 --libdir"
+  Right fh <- popen cmd Read
+      | Left err => do printLn err
+                       exitFailure
+  Right output <- fGetLine fh
+      | Left err => do printLn err
+                       exitFailure
+  pclose fh
+  let path ::: _ = split (== '\n') output
+  let pathWithSuffix = path ++ "-src"
+  pure pathWithSuffix
+
+||| Creates a response buffer if absent
+createResponseBuffer : IO ()
+createResponseBuffer =
+  when (not !(bufexists responseBufferName)) $
+    do nvimCommand "let prevBuf = bufnr(@#)"
+       nvimCommand $ "badd " ++ responseBufferName
+       nvimCommand $ "b " ++ responseBufferName
+       nvimCommand "set buftype=nofile"
+       nvimCommand "b #"
+       nvimCommand "let @# = prevBuf"
+
+||| Writes to the response buffer, if loaded in one of the windows
 writeToBuffer : Bool -> String -> IO ()
 writeToBuffer commented str = do
-  -- TODO: ensure buffer is opened
+  createResponseBuffer
   cwid <- primIO $ bufwinnr "."
-  rwid <- primIO $ bufwinnr "idris-response"
-  primIO $ nvimCommand $ show rwid ++ "wincmd w"
-  lastline <- primIO $ line "$"
-  primIO $ appendLines commented True lastline str
-  primIO $ nvimCommand "normal! G"
-  primIO $ nvimCommand $ show cwid ++ "wincmd w"
-  -- cur <- primIO getCurPos
-  -- primIO $ nvimCommand "b idris-response"
-  -- lastline <- primIO $ line "$"
-  -- primIO $ appendLines commented lastline str
-  -- primIO $ nvimCommand "normal! G"
-  -- primIO $ nvimCommand "b #"
-  -- primIO $ setCurPos cur
+  rwid <- primIO $ bufwinnr responseBufferName
+  when (rwid > 0) $ do
+   nvimCommand $ show rwid ++ "wincmd w"
+   lastline <- primIO $ line "$"
+   primIO $ appendLines commented True lastline str
+   nvimCommand "normal! G"
+   nvimCommand $ show cwid ++ "wincmd w"
 
 splitMessages : String -> List String -> List String
 splitMessages recv acc =
@@ -89,94 +150,202 @@ splitMessages recv acc =
                        splitMessages rest (snoc acc msg)
        Nothing => acc
 
-process : IDEResult -> IO ()
+runFind : (installDir : String) -> (searchStr : String) -> IO (List String)
+runFind installDir searchStr = do
+  let cmd = "fd -p " ++ searchStr ++ " . " ++ installDir
+  Right f <- popen cmd Read
+    | Left err => do putStrLn (show err)
+                     exitFailure
+  ret <- rec f []
+  pclose f
+  pure ret
+where
+  rec : File -> List String -> IO (List String)
+  rec f got = do Right line <- fGetLine f
+                   | Left err => do putStrLn (show err)
+                                    exitFailure
+                 if line == "" || line == "\n"
+                   then
+                     pure $ reverse got
+                   else do
+                     let line = trimNewLineAtEnd line
+                     nvimCommand $ "echom 'runFind: " ++ show line ++ "'"
+                     rec f (line :: got)
+
+record NamePositionInfo where
+  constructor MkNamePositionInfo
+  name : String
+  filename : String
+  startRow : Integer
+  startColumn : Integer
+  endRow : Integer
+  endColumn : Integer
+
+||| Checks if the provided SExp is a valid entry of a name-at output.
+||| Parses the entry into a record with info in that case.
+validateNameAtEntry : SExp -> Maybe NamePositionInfo
+validateNameAtEntry (SExpList [ StringAtom name
+                                    , StringAtom filename
+                                    , IntegerAtom sr
+                                    , IntegerAtom sc
+                                    , IntegerAtom er
+                                    , IntegerAtom ec]) =
+  Just $ MkNamePositionInfo name filename sr sc er ec
+validateNameAtEntry _ = Nothing
+
+||| Opens the file in the focused buffer, navigating to the provided row and column
+jumpToDef : (filePath : String) -> (row : Integer) -> (col : Integer) -> IO ()
+jumpToDef path row col = do
+  nvimCommand "write"
+  nvimCommand $ "edit " ++ path
+  nvimCommand $ "call setpos('.', [0, " ++ show (row + 1) ++ ", " ++ show (col + 1) ++ ", 0])"
+  nvimCommand $ "normal! zz"
+
+zipWithIndex : List a -> List (a, Nat)
+zipWithIndex xs = zip xs [0 .. length xs `minus` 1]
+
+process : (params : Parameters)
+       => IDEResult
+       -> IO ()
 process (OK idx res) = do
   case !(primIO $ getCmdFromHistory idx) of
     Just (Interpret sel) => do
       let SExpList ((StringAtom ls) :: _) = res
-        | x => primIO $ nvimCommand $ "echom 'Invalid response to Interpret" ++ show res ++ "'"
+        | x => nvimCommand $ "echom 'Invalid response to Interpret" ++ show res ++ "'"
       writeToBuffer False $ "-- " ++ !(primIO currenttime) ++ "\n" ++ ls
       primIO $ deleteCmdInHistory idx
     Just (LoadFile path _) => do
       writeToBuffer True $ !(primIO currenttime) ++ "\nSuccesfully reloaded " ++ path
       primIO $ deleteCmdInHistory idx
     Just (TypeOf name _) => do
+
       let SExpList ((StringAtom ls) :: _) = res
-        | x => primIO $ nvimCommand $ "echom 'Invalid response to TypeOf" ++ show res ++ "'"
+        | x => nvimCommand $ "echom 'Invalid response to TypeOf" ++ show res ++ "'"
       writeToBuffer False $ "-- " ++ !(primIO currenttime) ++ "\n" ++ ls
       primIO $ deleteCmdInHistory idx
+    Just (NameAt name _) => do
+      let SExpList [SExpList list] = res
+        | x => nvimCommand $ "echom 'Invalid response to NameAt" ++ show res ++ "'"
+      let Just validated@(first :: rest) = sequence $ map validateNameAtEntry list
+        | Just [] => writeToBuffer False $ "-- " ++ !(primIO currenttime) ++ "\n"
+                         ++ "Could not find anything on " ++ name
+        | Nothing => nvimCommand $ "echom 'Invalid response to NameAt" ++ show res ++ "'"
+      case rest of
+        [] => do -- exactly one name return by the IDE
+          [fullPath] <- runFind params.sourceDir first.filename -- one candidate found
+            | multiple@(_ :: _) => do
+                let relative = filter isRelative multiple
+                case relative of
+                  [] => nvimCommand "echoe \"Can't handle multiple absolute candidates\""
+                  [singlePath] =>
+                    jumpToDef singlePath first.startRow first.startColumn
+                  _ => nvimCommand "echoe \"Can't handle multiple relative candidates\""
+            | [] => nvimCommand "echoe 'Candidates not found'"
+          jumpToDef fullPath first.startRow first.startColumn
+        _ :: _ => do
+          let fzfInput = map (\(x, i) => "[" ++ show i ++ "] " ++ x.filename)
+                             (zipWithIndex validated)
+          -- TODO previews
+          fzfWindowBottom name fzfInput \file =>
+            -- I (Russoul) don't know why, but the fzf vim plugin calls this callback with the empty string
+            -- in addition to a normal call with the supplied choice.
+            -- So we have to filter out that empty redundant call here
+            when (file /= "") $ do
+              nvimCommand $ "echom 'file is: " ++ file ++ "'"
+              let _ :: iStr :: _ = matchlist file "\\v\\[([0-9]+)\\].+"
+                | _ => nvimCommand $ "echoe 'Bad match while processing name-at'"
+              let Just i = parsePositive {a = Nat} iStr
+                | _ => nvimCommand $ "echoe 'Bad match while processing name-at'"
+              let Just (entry, _) = find (\(_, j) => i == j) (zipWithIndex validated)
+                | _ => nvimCommand $ "echoe 'Bad match while processing name-at'"
+              nvimCommand $ "echom 'entry filename is: " ++ entry.filename ++ "'"
+              candidates <- runFind params.sourceDir entry.filename
+              case candidates of
+                [] => writeToBuffer False $ "-- " ++ !(primIO currenttime) ++ "\n"
+                                 ++ "Could not find anything on " ++ name
+                [singlePath] => jumpToDef singlePath entry.startRow entry.startColumn
+                many => do
+                  -- Prioritise relative paths over absolute ones,
+                  -- in case multiple files are found by the find utility
+                  let relative = filter isRelative many
+                  case relative of
+                    [] => nvimCommand "echoe \"Can't handle multiple absolute candidates\""
+                    [singlePath] =>
+                      jumpToDef singlePath entry.startRow entry.startColumn
+                    _ => nvimCommand "echoe \"Can't handle multiple relative candidates\""
+              primIO $ deleteCmdInHistory idx
     Just (DocsFor name _) => do
       let SExpList ((StringAtom ls) :: _) = res
-        | x => primIO $ nvimCommand $ "echom 'Invalid response to DocsFor" ++ show res ++ "'"
+        | x => nvimCommand $ "echom 'Invalid response to DocsFor" ++ show res ++ "'"
       writeToBuffer False $ "-- " ++ !(primIO currenttime) ++ "\n" ++ ls
       primIO $ deleteCmdInHistory idx
     Just (CaseSplit line col name) => do
       let SExpList [StringAtom ls] = res
-        | x => primIO $ nvimCommand $ "echom 'Invalid response to CaseSplit" ++ show res ++ "'"
+        | x => nvimCommand $ "echom 'Invalid response to CaseSplit" ++ show res ++ "'"
       primIO $ deleteLine (cast line)
       primIO $ appendLines False False (cast line - 1) ls
       primIO $ deleteCmdInHistory idx
     Just (AddClause line name) => do
       let SExpList [StringAtom ls] = res
-        | x => primIO $ nvimCommand $ "echom 'Invalid response to AddClause" ++ show res ++ "'"
+        | x => nvimCommand $ "echom 'Invalid response to AddClause" ++ show res ++ "'"
       primIO $ appendLines False False (cast line) ls
       primIO $ deleteCmdInHistory idx
     Just (ExprSearch line name _ _) => do
       let SExpList [StringAtom ls] = res
-        | x => primIO $ nvimCommand $ "echom 'Invalid response to ExprSearch" ++ show res ++ "'"
-      primIO $ nvimCommand $ "s/" ++ (strCons '?' name) ++ "/" ++ ls ++ "/"
+        | x => nvimCommand $ "echom 'Invalid response to ExprSearch" ++ show res ++ "'"
+      nvimCommand $ "s/" ++ (strCons '?' name) ++ "/" ++ ls ++ "/"
       primIO $ putLastSearch ls
       primIO $ deleteCmdInHistory idx
     Just ExprSearchNext => do
       -- TODO: How we rollback?
       let SExpList [StringAtom ls] = res
-        | x => primIO $ nvimCommand $ "echom 'Invalid response to ExprSearch" ++ show res ++ "'"
+        | x => nvimCommand $ "echom 'Invalid response to ExprSearch" ++ show res ++ "'"
       writeToBuffer True $ "Inline substitution of next expression search is not available\n" ++ ls
       primIO $ deleteCmdInHistory idx
     Just (GenerateDef line name) => do
       let SExpList [StringAtom ls] = res
-        | x => primIO $ nvimCommand $ "echom 'Invalid response to GenerateDef" ++ show res ++ "'"
+        | x => nvimCommand $ "echom 'Invalid response to GenerateDef" ++ show res ++ "'"
       primIO $ appendLines False False (cast line) ls
       primIO $ deleteCmdInHistory idx
     Just GenerateDefNext => do
       -- TODO: How we rollback?
       let SExpList [StringAtom ls] = res
-        | x => primIO $ nvimCommand $ "echom 'Invalid response to ExprSearch" ++ show res ++ "'"
+        | x => nvimCommand $ "echom 'Invalid response to ExprSearch" ++ show res ++ "'"
       writeToBuffer True $ "Inline substitution of next definition is not available\n" ++ ls
       primIO $ deleteCmdInHistory idx
     Just (MakeLemma line name) => do
       -- TODO: How we find where to put the lemma? (Maybe, go to the previous paragraph and append there)
       let SExpList [StringAtom ls] = res
-        | x => primIO $ nvimCommand $ "echom 'Invalid response to ExprSearch" ++ show res ++ "'"
+        | x => nvimCommand $ "echom 'Invalid response to ExprSearch" ++ show res ++ "'"
       writeToBuffer False $ "Inline substitution of make lemma is not available\n" ++ ls
       primIO $ deleteCmdInHistory idx
     Just (MakeCase line name) => do
       -- TODO: Feels like a hack
       let SExpList [StringAtom ls] = res
-        | x => primIO $ nvimCommand $ "echom 'Invalid response to MakeCase" ++ show res ++ "'"
+        | x => nvimCommand $ "echom 'Invalid response to MakeCase" ++ show res ++ "'"
       primIO $ deleteLine (cast line)
       primIO $ appendLines False False (cast line - 1) ls
       primIO $ deleteCmdInHistory idx
     Just (MakeWith line name) => do
       -- TODO: Feels like a hack
       let SExpList [StringAtom ls] = res
-        | x => primIO $ nvimCommand $ "echom 'Invalid response to MakeWith" ++ show res ++ "'"
+        | x => nvimCommand $ "echom 'Invalid response to MakeWith" ++ show res ++ "'"
       primIO $ deleteLine (cast line)
       primIO $ appendLines False False (cast line - 1) ls
       primIO $ deleteCmdInHistory idx
     Just (Metavariables _) => do
       -- let SExpList [StringAtom ls] = res
-      --   | x => primIO $ nvimCommand $ "echom 'Invalid response to Metavariables" ++ show res ++ "'"
+      --   | x => nvimCommand $ "echom 'Invalid response to Metavariables" ++ show res ++ "'"
       writeToBuffer False $ "-- " ++ !(primIO currenttime) ++ "\n" ++ (show res)
       primIO $ deleteCmdInHistory idx
     Just (BrowseNamespace name) => do
       let SExpList ((StringAtom ls) :: _) = res
-        | x => primIO $ nvimCommand $ "echom 'Invalid response to BrowseNamespace" ++ show res ++ "'"
+        | x => nvimCommand $ "echom 'Invalid response to BrowseNamespace" ++ show res ++ "'"
       writeToBuffer False $ "-- " ++ !(primIO currenttime) ++ "\n" ++ ls
       primIO $ deleteCmdInHistory idx
 --     Just (EnableSyntax _) => do
 --       let SExpList ((StringAtom ls) :: _) = res
---         | x => primIO $ nvimCommand $ "echom 'Invalid response to EnableSyntax"++ show res ++ "'"
+--         | x => nvimCommand $ "echom 'Invalid response to EnableSyntax"++ show res ++ "'"
 --       writeToBuffer True $ !(primIO currenttime) ++ "\nServer message: \"" ++ ls ++ "\""
 --       primIO $ deleteCmdInHistory idx
     Just GetOptions => do
@@ -195,13 +364,16 @@ process (Output idx res) = primIO $ deleteCmdInHistory idx
 process (Version (SExpList [IntegerAtom major, IntegerAtom minor])) = do
   let msg = !(primIO currenttime) ++ "\nIdris2 IDE Mode server version " ++ show major ++ "." ++ show minor
   writeToBuffer True msg
-process _ = primIO $ nvimCommand $ "echom 'Invalid message from the server'"
+process _ = nvimCommand $ "echom 'Invalid message from the server'"
 
-connectIdris2 : String -> Int -> IO OpaqueDict
+connectIdris2 : (params : Parameters)
+             => String
+             -> Int
+             -> IO OpaqueDict
 connectIdris2 host port = do
-  primIO $ nvimCommand "echom 'Starting connection...'"
+  nvimCommand "echom 'Starting connection...'"
   client <- newTCP
-  primIO $ nvimCommand "echom 'Created new tcp socket...'"
+  nvimCommand "echom 'Created new tcp socket...'"
   connect client host port
     (do readStart client
           (\recv => do
@@ -209,15 +381,15 @@ connectIdris2 host port = do
               for_ msgs $ \msg => do
                 let head = substr 0 5 msg
                 if (head == "(:out")
-                   then primIO $ nvimCommand $ "echo 'skipped output'"
+                   then nvimCommand $ "echo 'skipped output'"
                    else do let Right sexp = parseSExp msg
-                             | Left err => primIO $ nvimCommand $ "echom 'invalid response: " ++ show err ++ "'"
+                             | Left err => nvimCommand $ "echom 'invalid response: " ++ show err ++ "'"
                            let Just res = getResult sexp
-                             | Nothing => primIO $ nvimCommand $ "echom 'invalid response: " ++ show sexp ++ "'"
+                             | Nothing => nvimCommand $ "echom 'invalid response: " ++ show sexp ++ "'"
                            process res)
-          (\err => primIO $ nvimCommand $ "echom 'read err: " ++ err ++ "'")
+          (\err => nvimCommand $ "echom 'read err: " ++ err ++ "'")
           (pure ()))
-    (\err => primIO $ nvimCommand $ "echom 'connect error: " ++ err ++ "'")
+    (\err => nvimCommand $ "echom 'connect error: " ++ err ++ "'")
   -- write client !(buildCommand $ EnableSyntax False) -- Still not merged
   pure client
 
@@ -233,6 +405,7 @@ quitServer = do
 -- TODO: Use IORef instead of an hacky global variable. How we pass it to
 --       callbacks without loosing generality?
 spawnAndConnectIdris2 : HasIO io
+                     => (params : Parameters)
                      => Ref Server (Maybe OpaqueDict)
                      => Ref Client (Maybe OpaqueDict)
                      => (String, Int)
@@ -240,27 +413,24 @@ spawnAndConnectIdris2 : HasIO io
                      -> io ()
 spawnAndConnectIdris2 (shost, sport) (chost, cport) = do
   Nothing <- get Server
-    | Just _ => primIO $ nvimCommand "echom 'Idris2 process already spawned'"
+    | Just _ => nvimCommand "echom 'Idris2 process already spawned'"
   stdout <- newPipe
   let opts = spawnOpts (shost ++ ":" ++ show sport) stdout
-  d <- spawn "idris2" opts (\code, signal => primIO $ nvimCommand $ "echom 'Idris2 process closed with code " ++ show code ++ "'")
+  d <- spawn "idris2" opts (\code, signal => nvimCommand $ "echom 'Idris2 process closed with code " ++ show code ++ "'")
   let handle : OpaqueDict = getField d "handle"
   put Server (Just handle)
-  readStart stdout (\msg => do primIO $ nvimCommand $ "echom 'server: " ++ msg ++ "'"
+  readStart stdout (\msg => do nvimCommand $ "echom 'server: " ++ msg ++ "'"
                                if trim msg == show sport
                                   then do client <- connectIdris2 chost cport
                                           primIO $ setGlobalClient client -- TODO: can we remove it?
                                           put Client (Just client)
                                           readStop stdout
-                                  else do primIO $ nvimCommand $ "echom 'wrong port " ++ msg ++ "'"
+                                  else do nvimCommand $ "echom 'wrong port " ++ msg ++ "'"
                                           quitServer)
-                   (\err => do primIO $ nvimCommand $ "echom 'err: " ++ err ++ "'"
+                   (\err => do nvimCommand $ "echom 'err: " ++ err ++ "'"
                                quitServer)
-                   (do primIO $ nvimCommand "echom 'Idris2 stdout closed'"
+                   (do nvimCommand "echom 'Idris2 stdout closed'"
                        quitServer)
-
-%foreign "name, _ => vim.fn.bufexists(name)"
-bufexists : String -> PrimIO Int
 
 main : IO ()
 main = do
@@ -269,20 +439,24 @@ main = do
   serverRef <- newRef Server $ the (Maybe OpaqueDict) Nothing
   clientRef <- newRef Client $ the (Maybe OpaqueDict) Nothing
 
+  sourceDir <- getSourceDirectory
+
   autostart <- getGlobalBoolVar "idris2_autostart" True
 
+  let params = MkParameters sourceDir
+
   when autostart $ do
-    primIO $ nvimCommand "set maxfuncdepth=10000"
-    primIO $ nvimCommand "echom 'starting idris2 ide mode plugin'"
+    nvimCommand "set maxfuncdepth=10000"
+    nvimCommand "echom 'starting idris2 ide mode plugin'"
 
     externalClientOpt <- getGlobalBoolVar "idris2_external_server" False
     if externalClientOpt
-       then do primIO $ nvimCommand "echom 'starting with external server'"
+       then do nvimCommand "echom 'starting with external server'"
                host <- getGlobalStringVar "idris2_external_host" "127.0.0.1"
                port <- getGlobalIntVar "idris2_external_port" 38398
                client <- connectIdris2 host port
                primIO $ setGlobalClient client
-       else do primIO $ nvimCommand "echom 'starting server'"
+       else do nvimCommand "echom 'starting server'"
                port <- getGlobalIntVar "idris2_server_port" 38398
                spawnAndConnectIdris2 ("localhost", port) ("127.0.0.1", port)
 
@@ -291,6 +465,10 @@ main = do
               (commandBinding True `{{loadCurrent}})
     nnoremap !(getGlobalStringVar "idris2_typeOf_key" "<LocalLeader>t")
               (commandBinding True `{{typeOf}})
+    nnoremap !(getGlobalStringVar "idris2_typeOfPrompt_key" "<LocalLeader>T")
+              (commandBinding True `{{typeOfPrompt}})
+    vnoremap !(getGlobalStringVar "idris2_typeOf_key" "<LocalLeader>t")
+              (commandBinding True `{{typeOfSel}})
     nnoremap !(getGlobalStringVar "idris2_docOverview_key" "<LocalLeader>d")
               (commandBinding True `{{docOverview}})
     nnoremap !(getGlobalStringVar "idris2_caseSplit_key" "<LocalLeader>c")
@@ -311,19 +489,31 @@ main = do
               (commandBinding True `{{makeCase}})
     nnoremap !(getGlobalStringVar "idris2_makeWith_key" "<LocalLeader>w")
               (commandBinding True `{{makeWith}})
+    nnoremap !(getGlobalStringVar "idris2_jumpTo_key" "<LocalLeader>j")
+              (commandBinding True `{{nameAt}})
+    nnoremap !(getGlobalStringVar "idris2_jumpToPrompt_key" "<LocalLeader>J")
+              (commandBinding True `{{nameAtPrompt}})
+    vnoremap !(getGlobalStringVar "idris2_jumpTo_key" "<LocalLeader>j")
+              (commandBinding True `{{nameAtSel}})
     vnoremap !(getGlobalStringVar "idris2_interpret_key" "<LocalLeader>e")
               (commandBinding True `{{interpret}}) -- evaluates selected code
 
     -- AUTOCOMMANDS
     loadOnStart <- getGlobalBoolVar "idris2_load_on_start" True
     when loadOnStart $ do
-      primIO $ nvimCommand "augroup IdrisIDE"
-      primIO $ nvimCommand $ "autocmd BufNewFile,BufRead *.idr " ++ commandBinding False `{{loadCurrent}}
-      primIO $ nvimCommand "augroup end"
+      nvimCommand "augroup IdrisLoadOnRead"
+      nvimCommand " autocmd!"
+      nvimCommand $ "autocmd BufNewFile,BufRead *.idr " ++ commandBinding False `{{loadCurrent}}
+      nvimCommand "augroup end"
+    -- Set up the response buffer
+    nvimCommand "augroup IdrisSetBufType"
+    nvimCommand $ " autocmd!"
+    nvimCommand $ " autocmd BufEnter " ++ responseBufferName ++ " set buftype=nofile|set syntax=idris2"
+    nvimCommand "augroup end"
 
     -- RESPONSE BUFFER
-    primIO $ nvimCommand "vertical rightbelow split"
-    primIO $ nvimCommand "badd idris-response"
-    primIO $ nvimCommand "b idris-response"
-    primIO $ nvimCommand "set buftype=nofile"
-    primIO $ nvimCommand "wincmd h"
+    nvimCommand "vertical rightbelow split"
+    nvimCommand "badd idris-response"
+    nvimCommand "b idris-response"
+    nvimCommand "set buftype=nofile"
+    nvimCommand "wincmd h"


### PR DESCRIPTION
To compile this, one has to locally merge [PR #740](https://github.com/idris-lang/Idris2/pull/740) into their Idris 2 project until the PR is accepted.

This requires the [fd](https://github.com/sharkdp/fd) utility and [fzf](https://github.com/junegunn/fzf.vim) to be installed on your system and as a vim plugin.

This PR implements go-to-definition feature: ability to jump to global definitions across source files by name. By default you can use `<LocalLeader>j` in normal/visual mode or `<LocalLeader>J` in normal mode to trigger the action.

<ins>Prerequisites before using this feature:</ins>
You have to create a new folder inside your `.idris2` directory: `idris2-0.2.1-src` and copy source code from `prelude`, `base`, `contrib`, `network`, `idris2`, etc., i.e. any package you use, into that folder. The plugin will then be able to access the source and open the source files on the fly.

Other small additions: 
  + FFIs for a few foreign vim functions
  + Proper syntax highlighting of the `idris-response` buffer
  + A check that the response buffer has been created and loaded in an active window before trying to write to it.
  + Other tiny changes not worth mentioning here 😅 

#### EDIT:
Not sure if this should be merged yet or we have to at least warn the users and document the required dependencies accordingly.